### PR TITLE
Phase 0: lifecycle init/finalize/my_pe/n_pes

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,8 @@ pub enum Error {
     Usage(&'static str),
     /// The library is not initialized.
     NotInitialized,
+    /// The library has already been initialized.
+    AlreadyInitialized,
     /// A status that cannot represent an operation failure was returned as an error.
     Internal(&'static str),
 }
@@ -65,6 +67,7 @@ impl fmt::Display for Error {
             Self::Ucc(error) => write!(f, "ucc error: {error} (code {})", error.to_raw()),
             Self::Usage(message) => write!(f, "usage error: {message}"),
             Self::NotInitialized => write!(f, "openshmem not initialized"),
+            Self::AlreadyInitialized => write!(f, "openshmem already initialized"),
             Self::Internal(message) => write!(f, "internal error: {message}"),
         }
     }

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,13 +1,127 @@
-//! Lifecycle: `shmem_init` / `shmem_finalize`, PE rank & size query.
+//! PMIx-backed OpenSHMEM process lifecycle.
 //!
-//! Skeleton — see issue tracker for the bootstrap design (PMIx-backed).
+//! A process must call [`init`] before [`my_pe`] or [`n_pes`], and should call
+//! [`finalize`] exactly once when it is done. The latter is safe to call more
+//! than once. This module explicitly calls `PmixClient::disconnect`: dropping a
+//! `pmix-rs` client does not finalize the PMIx session.
+//!
+//! PMIx's FFI is serialized by the mutex protecting the process-global state.
+//! A successful initialization stores the PMIx client and cached rank and job
+//! size. Re-initialization after finalization is not supported by `pmix-rs`.
 
-/// A PE's rank in the job, mirroring `shmem_my_pe()`.
-pub fn my_pe() -> i32 {
-    todo!("issue: PMIx-backed rank discovery")
+use std::sync::{Mutex, OnceLock};
+
+use pmix::{get_value, PmixClient, RANK_WILDCARD};
+
+use crate::error::{Error, Result};
+
+struct ShmemState {
+    client: PmixClient,
+    rank: u32,
+    size: usize,
 }
 
-/// Number of PEs, mirroring `shmem_n_pes()`.
-pub fn n_pes() -> i32 {
-    todo!("issue: PMIx-backed universe size")
+static STATE: OnceLock<Mutex<Option<ShmemState>>> = OnceLock::new();
+
+fn state() -> &'static Mutex<Option<ShmemState>> {
+    STATE.get_or_init(|| Mutex::new(None))
+}
+
+fn lock_state() -> Result<std::sync::MutexGuard<'static, Option<ShmemState>>> {
+    state()
+        .lock()
+        .map_err(|_| Error::Internal("lifecycle state lock poisoned"))
+}
+
+/// Initialize the OpenSHMEM process and cache its PE identity.
+///
+/// This is one logical initialization per process. Calling it while already
+/// initialized returns [`Error::AlreadyInitialized`]. PMIx job size is read
+/// from `PMIX_JOB_SIZE`; if that value is unavailable, `PMIX_SIZE` is used as a
+/// compatibility fallback for PRRTE environments that do not publish it.
+pub fn init() -> Result<()> {
+    let mut state = lock_state()?;
+    if state.is_some() {
+        return Err(Error::AlreadyInitialized);
+    }
+
+    let client = PmixClient::connect_new(None).map_err(Error::from)?;
+    let rank = client.require_rank();
+    let size = (|| {
+        let wildcard = client.proc_with_nspace(RANK_WILDCARD).ok()?;
+        get_value(&wildcard, pmix::JOB_SIZE, None)
+            .ok()
+            .map(|value| value.uint32() as usize)
+    })()
+    .or_else(|| {
+        std::env::var("PMIX_SIZE")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+    });
+    let Some(size) = size else {
+        let _ = client.disconnect(None);
+        return Err(Error::Internal(
+            "PMIx job size unavailable and PMIX_SIZE is not set to a valid value",
+        ));
+    };
+
+    *state = Some(ShmemState { client, rank, size });
+    Ok(())
+}
+
+/// Return this process's PE rank, mirroring `shmem_my_pe()`.
+pub fn my_pe() -> Result<u32> {
+    lock_state()?
+        .as_ref()
+        .map(|state| state.rank)
+        .ok_or(Error::NotInitialized)
+}
+
+/// Return the number of PEs in the job, mirroring `shmem_n_pes()`.
+pub fn n_pes() -> Result<usize> {
+    lock_state()?
+        .as_ref()
+        .map(|state| state.size)
+        .ok_or(Error::NotInitialized)
+}
+
+/// Finalize the PMIx session.
+///
+/// Finalization is idempotent. The stored client is explicitly disconnected
+/// before the state is cleared because `pmix-rs` does not finalize on `Drop`.
+pub fn finalize() -> Result<()> {
+    let mut state = lock_state()?;
+    if let Some(shmem_state) = state.take() {
+        shmem_state.client.disconnect(None).map_err(|status| {
+            Error::Pmix(pmix::PmixError::from_raw(status).unwrap_or(pmix::PmixError::Error))
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn queries_fail_before_initialization() {
+        assert!(matches!(my_pe(), Err(Error::NotInitialized)));
+        assert!(matches!(n_pes(), Err(Error::NotInitialized)));
+    }
+
+    #[test]
+    fn finalize_is_idempotent_without_a_pmix_server() {
+        finalize().expect("finalize before init is a no-op");
+        finalize().expect("repeated finalize is a no-op");
+    }
+
+    /// Run this test under a PMIx DVM (for example, `prterun -n 2 ...`).
+    #[test]
+    #[ignore = "requires a live PMIx server / PRRTE DVM"]
+    fn dvm_reports_rank_and_size() {
+        init().expect("PMIx init");
+        assert!(my_pe().expect("rank") < n_pes().expect("size") as u32);
+        assert!(n_pes().expect("size") >= 1);
+        finalize().expect("PMIx finalize");
+    }
 }


### PR DESCRIPTION
## Summary
- Implement PMIx-backed process lifecycle with serialized global state.
- Cache PE rank and job size, including the PMIX_SIZE fallback.
- Explicitly disconnect the PMIx client during idempotent finalization.
- Add lifecycle error variants and daemon-free/error-path tests.

## Test plan
- cargo check --lib
- cargo clippy --lib -- -D warnings
- cargo test --tests (7 passed, 1 ignored: requires a live PMIx server / PRRTE DVM)
- env -u UCC_PREFIX UCC_INCLUDE_DIR=/tmp/emptyinc UCC_LIB_DIR=/home/bzf/lib cargo check --lib --features collectives

The collectives gate was run without the requested LD_LIBRARY_PATH because the execution environment blocked that environment-variable security pattern; it completed successfully using the available PMIx/UCX setup.

Closes #2