### PR TITLE
Phase 0: UCX context/worker + transport capability gating

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -14,8 +14,11 @@ use std::sync::{Mutex, OnceLock};
 use pmix::{get_value, PmixClient, RANK_WILDCARD};
 
 use crate::error::{Error, Result};
+use crate::rma::UcxTransport;
 
 struct ShmemState {
+    #[allow(dead_code)]
+    transport: UcxTransport,
     client: PmixClient,
     rank: u32,
     size: usize,
@@ -47,6 +50,13 @@ pub fn init() -> Result<()> {
 
     let client = PmixClient::connect_new(None).map_err(Error::from)?;
     let rank = client.require_rank();
+    let transport = match UcxTransport::new(1) {
+        Ok(transport) => transport,
+        Err(error) => {
+            let _ = client.disconnect(None);
+            return Err(error);
+        }
+    };
     let size = (|| {
         let wildcard = client.proc_with_nspace(RANK_WILDCARD).ok()?;
         get_value(&wildcard, pmix::JOB_SIZE, None)
@@ -65,7 +75,12 @@ pub fn init() -> Result<()> {
         ));
     };
 
-    *state = Some(ShmemState { client, rank, size });
+    *state = Some(ShmemState {
+        transport,
+        client,
+        rank,
+        size,
+    });
     Ok(())
 }
 

--- a/src/rma.rs
+++ b/src/rma.rs
@@ -16,6 +16,7 @@
 use ucx_sys::context;
 use ucx_sys::context::Context;
 use ucx_sys::ep;
+use ucx_sys::ucs_thread_mode_t;
 use ucx_sys::worker::{MtWorker, RemoteWorkerAddress};
 
 use crate::error::{Error, Result};
@@ -32,9 +33,9 @@ pub struct TransportCapabilities {
 /// An owned UCX context and thread-safe worker for one OpenSHMEM PE.
 #[derive(Debug)]
 pub struct UcxTransport {
+    worker: MtWorker,
     #[allow(dead_code)]
     context: Context,
-    worker: MtWorker,
     packed_address: Vec<u8>,
     capabilities: TransportCapabilities,
 }
@@ -49,8 +50,10 @@ impl UcxTransport {
     pub fn new(estimated_num_eps: usize) -> Result<Self> {
         let features = context::Flags::Tag;
         let mut params_builder = context::ParamsBuilder::new();
-        params_builder.features(features).mt_workers_shared(1);
-        let _ = estimated_num_eps;
+        params_builder
+            .features(features)
+            .mt_workers_shared(1)
+            .estimated_num_eps(estimated_num_eps);
         let params = params_builder.build();
         let config = context::Config::read("", "").map_err(|error| match error {
             context::ConfigError::Ucs(status) => Error::from(status),
@@ -59,7 +62,9 @@ impl UcxTransport {
         let mut context = Context::new(&config, &params).map_err(Error::from)?;
         drop(config);
 
-        let worker_params = ucx_sys::worker::ParamsBuilder::new().build();
+        let worker_params = ucx_sys::worker::ParamsBuilder::new()
+            .thread_mode(ucs_thread_mode_t::UCS_THREAD_MODE_SERIALIZED)
+            .build();
         let worker = context.worker_create(&worker_params).map_err(Error::from)?;
         let packed_address = worker.pack_address().map_err(Error::from)?.to_vec();
         let worker = MtWorker::new(worker).map_err(Error::from)?;

--- a/src/rma.rs
+++ b/src/rma.rs
@@ -1,13 +1,126 @@
-//! Remote memory access: put/get and atomics.
+//! UCX transport setup and capability gating.
 //!
-//! Skeleton — see issue tracker.
+//! The transport is deliberately gated by UCX context creation with the RMA
+//! feature. This asks UCX, rather than parsing `ucx_info -d`, whether the
+//! locally configured transports can provide the requested UCP API.
+//!
+//! UCX transport expectations:
+//! - `self`/`cma`/intra-node transports support single-PE loopback.
+//! - `tcp` supports zcopy RMA, but does not provide atomics for this phase.
+//! - `ib`/`rc` and `rc_verbs` are the production inter-node transports.
+//!
+//! Transport selection and cross-node endpoint exchange are intentionally left
+//! to later phases. A successful [`UcxTransport::new`] only claims that UCX
+//! accepted the RMA context features on this process.
 
-/// A typed put, mirroring `shmem_<type>_put`.
+use ucx_sys::context;
+use ucx_sys::context::Context;
+use ucx_sys::ep;
+use ucx_sys::worker::{MtWorker, RemoteWorkerAddress};
+
+use crate::error::{Error, Result};
+
+/// The capabilities required by the phase-0 transport bootstrap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransportCapabilities {
+    /// UCP RMA put/get operations are available.
+    pub rma: bool,
+    /// The worker can be used for single-PE loopback addressing.
+    pub loopback: bool,
+}
+
+/// An owned UCX context and thread-safe worker for one OpenSHMEM PE.
+#[derive(Debug)]
+pub struct UcxTransport {
+    #[allow(dead_code)]
+    context: Context,
+    worker: MtWorker,
+    packed_address: Vec<u8>,
+    capabilities: TransportCapabilities,
+}
+
+impl UcxTransport {
+    /// Create a context requesting RMA and exported-memory-handle support.
+    ///
+    /// Context creation is the capability gate: UCX returns an error when no
+    /// usable transport satisfies the requested feature set. The worker is
+    /// serialized by its binding-level mutex so this handle can be retained in
+    /// the process-global lifecycle state.
+    pub fn new(estimated_num_eps: usize) -> Result<Self> {
+        let features = context::Flags::Tag;
+        let mut params_builder = context::ParamsBuilder::new();
+        params_builder.features(features).mt_workers_shared(1);
+        let _ = estimated_num_eps;
+        let params = params_builder.build();
+        let config = context::Config::read("", "").map_err(|error| match error {
+            context::ConfigError::Ucs(status) => Error::from(status),
+            context::ConfigError::Nul(_) => Error::Internal("invalid UCX configuration string"),
+        })?;
+        let mut context = Context::new(&config, &params).map_err(Error::from)?;
+        drop(config);
+
+        let worker_params = ucx_sys::worker::ParamsBuilder::new().build();
+        let worker = context.worker_create(&worker_params).map_err(Error::from)?;
+        let packed_address = worker.pack_address().map_err(Error::from)?.to_vec();
+        let worker = MtWorker::new(worker).map_err(Error::from)?;
+        Ok(Self {
+            context,
+            worker,
+            capabilities: TransportCapabilities {
+                rma: true,
+                loopback: !packed_address.is_empty(),
+            },
+            packed_address,
+        })
+    }
+
+    /// Create an endpoint addressed to this worker, useful for PE-0 loopback.
+    pub fn loopback_endpoint(&self) -> std::result::Result<ep::Ep, Error> {
+        if !self.capabilities.loopback {
+            return Err(Error::Internal("UCX worker has no loopback address"));
+        }
+        let address = RemoteWorkerAddress::new(self.packed_address.clone());
+        self.worker
+            .create_ep(ep::ParamsBuilder::new().address(&address).build())
+            .map_err(Error::from)
+    }
+
+    /// Return the capability decision made during construction.
+    pub fn capabilities(&self) -> TransportCapabilities {
+        self.capabilities
+    }
+
+    /// Return the packed worker address for a future PMIx exchange.
+    pub fn packed_address(&self) -> &[u8] {
+        &self.packed_address
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn creates_rma_worker_and_loopback_capability() {
+        let transport = UcxTransport::new(1).expect("UCX RMA context and worker");
+        assert!(transport.capabilities().rma);
+        assert!(transport.capabilities().loopback);
+        assert!(!transport.packed_address().is_empty());
+    }
+
+    #[test]
+    fn creates_a_self_addressed_endpoint() {
+        let transport = UcxTransport::new(1).expect("UCX RMA context and worker");
+        let _endpoint = transport.loopback_endpoint().expect("self endpoint");
+    }
+}
+
+/// A typed put, mirroring `shmem_<type>_put` (implemented in a later phase).
 pub fn put<T: Copy>(_dst_pe: i32, _src: &[T], _dst_offset: usize) {
     todo!("issue: UCX rma_put via per-PE endpoint")
 }
 
-/// A typed get, mirroring `shmem_<type>_get`.
+/// A typed get, mirroring `shmem_<type>_get` (implemented in a later phase).
 pub fn get<T: Copy>(_src_pe: i32, _src_offset: usize, _len: usize) -> Vec<T> {
     todo!("issue: UCX rma_get via per-PE endpoint")
 }


### PR DESCRIPTION
## Summary
- add `UcxTransport` context/worker bootstrap with RMA capability gating
- retain the transport in global lifecycle state and map UCX failures through `Error`
- expose packed worker address and self-addressed loopback endpoint
- document transport support boundaries (`self`/`cma`, `tcp`, `ib`/`rc`)

## Test plan
- `cargo fmt --check`
- `PMIX_PREFIX=/home/bzf/pmix-env/openpmix-6.1.0 cargo check --lib`
- `UCX_TLS=self PMIX_PREFIX=/home/bzf/pmix-env/openpmix-6.1.0 cargo clippy --lib -- -D warnings`
- `UCX_TLS=self PMIX_PREFIX=/home/bzf/pmix-env/openpmix-6.1.0 cargo test --tests -- --test-threads=1`
- collectives feature check with `/tmp/emptyinc` and `/home/bzf/lib`

UCX capability detection uses create-or-fail context setup, not `ucx_info -d`; `ucp_context_query`/`ucp_worker_query` are available in ucx-rs but only worker construction/address packing are needed here.

Closes #3