### PR TITLE
feat(bootstrap): add PMIx UCX handshake

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openshmem"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 rust-version = "1.85"
 description = "OpenSHMEM-style partitioned global address space (PGAS) library for Rust, built on pmix-rs (bootstrap) + ucx-rs (RMA/atomics) + ucc-rs (collectives)."
 license = "MIT"

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -42,6 +42,12 @@ The mapping mirrors how `osss-ucx/src/shmemc/ucx/*` wires the same three C libra
 4. `pmix::get_value` each peer PE → unpack rkey → `RemoteKey`, build per-PE endpoint.
 5. RMA/atomics now addressable on the peer's symmetric heap.
 
+`bootstrap::handshake` implements steps 3–4. It publishes the worker address,
+framed heap rkey, and heap base, then performs `commit` and a PMIx `fence`
+before any peer `get`. Each peer address creates a UCX endpoint and its complete
+framed rkey is passed to `RemoteKey::unpack`; the framed bytes and base are also
+retained in `PeerRkeys`.
+
 ## Symmetric addressing (`SymPtr`)
 
 Allocations from the symmetric heap are wrapped in a private `usize` ([`SymPtr`]

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -11,15 +11,9 @@ use crate::{
     symheap::{PeerRkeys, SymHeap},
 };
 
-#[allow(clippy::manual_c_str_literals)]
-pub static WORKER_ADDR_KEY: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"shmem.worker.addr\0") };
-#[allow(clippy::manual_c_str_literals)]
-pub static HEAP_RKEY_KEY: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"shmem.heap.rkey\0") };
-#[allow(clippy::manual_c_str_literals)]
-pub static HEAP_BASE_KEY: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"shmem.heap.base\0") };
+pub static WORKER_ADDR_KEY: &CStr = c"shmem.worker.addr";
+pub static HEAP_RKEY_KEY: &CStr = c"shmem.heap.rkey";
+pub static HEAP_BASE_KEY: &CStr = c"shmem.heap.base";
 
 const WORKER_ADDR_GET_KEY: &[u8] = b"shmem.worker.addr\0";
 const HEAP_RKEY_GET_KEY: &[u8] = b"shmem.heap.rkey\0";
@@ -33,7 +27,18 @@ pub struct PeerConnection {
     pub heap_base: u64,
 }
 
-// Endpoint handles are owned behind the process-global lifecycle mutex.
+// SAFETY: `Ep` and `RemoteKey` contain raw UCX handles and are intentionally
+// `!Send`. A `PeerConnection` is constructed only by `handshake` and is kept
+// in the private `ShmemState`; every access to that state, including the
+// eventual drop of these handles, is serialized by `STATE`. `ShmemState`
+// declares peers before the heap and transport, so endpoints and rkeys are
+// destroyed while their UCX worker/context are still alive; the heap then
+// unmaps while the context remains alive. No handle is moved or accessed
+// concurrently with another thread while live. `Send` is required because
+// the process-global `OnceLock<Mutex<Option<ShmemState>>>` owns the state and
+// may move it between the initializing and finalizing threads. There is no
+// safe alternative that preserves ownership of these opaque UCX handles and
+// the OpenSHMEM process-global lifecycle.
 unsafe impl Send for PeerConnection {}
 
 pub struct Bootstrap {
@@ -72,8 +77,10 @@ pub fn handshake(
         .map_err(|_| Error::Usage("failed to build heap base value"))?;
     put_value(PmixScope::Global.to_raw(), HEAP_BASE_KEY, &mut base).map_err(pmix_error)?;
     pmix::commit().map_err(pmix_error)?;
-    let proc = client.proc().ok_or(Error::NotInitialized)?;
-    pmix::fence(&proc, None).map_err(pmix_error)?;
+    let wildcard = client
+        .proc_with_nspace(pmix::RANK_WILDCARD)
+        .map_err(Error::from)?;
+    pmix::fence(&wildcard, None).map_err(pmix_error)?;
 
     let mut peer_rkeys = PeerRkeys::default();
     let mut peers = BTreeMap::new();

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,0 +1,154 @@
+//! PMIx KVS bootstrap for UCX worker addresses and symmetric-heap keys.
+
+use std::{collections::BTreeMap, ffi::CStr};
+
+use pmix::{get_value, put_value, PmixClient, PmixScope, PmixValueBuilder};
+use ucx_sys::{ep::Ep, rma::RemoteKey, worker::RemoteWorkerAddress};
+
+use crate::{
+    error::{Error, Result},
+    rma::UcxTransport,
+    symheap::{PeerRkeys, SymHeap},
+};
+
+#[allow(clippy::manual_c_str_literals)]
+pub static WORKER_ADDR_KEY: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"shmem.worker.addr\0") };
+#[allow(clippy::manual_c_str_literals)]
+pub static HEAP_RKEY_KEY: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"shmem.heap.rkey\0") };
+#[allow(clippy::manual_c_str_literals)]
+pub static HEAP_BASE_KEY: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"shmem.heap.base\0") };
+
+const WORKER_ADDR_GET_KEY: &[u8] = b"shmem.worker.addr\0";
+const HEAP_RKEY_GET_KEY: &[u8] = b"shmem.heap.rkey\0";
+const HEAP_BASE_GET_KEY: &[u8] = b"shmem.heap.base\0";
+
+pub struct PeerConnection {
+    #[allow(dead_code)]
+    endpoint: Ep,
+    #[allow(dead_code)]
+    rkey: RemoteKey,
+    pub heap_base: u64,
+}
+
+// Endpoint handles are owned behind the process-global lifecycle mutex.
+unsafe impl Send for PeerConnection {}
+
+pub struct Bootstrap {
+    pub peer_rkeys: PeerRkeys,
+    pub peers: BTreeMap<u32, PeerConnection>,
+}
+
+fn pmix_error(status: pmix::ffi::pmix_status_t) -> Error {
+    Error::Pmix(pmix::PmixError::from_raw(status).unwrap_or(pmix::PmixError::Error))
+}
+
+fn put_bytes(key: &CStr, bytes: &[u8]) -> Result<()> {
+    let mut value = PmixValueBuilder::new()
+        .byte_object(bytes)
+        .map_err(|_| Error::Usage("bootstrap byte value must not be empty"))?
+        .build()
+        .map_err(|_| Error::Usage("failed to build bootstrap byte value"))?;
+    put_value(PmixScope::Global.to_raw(), key, &mut value).map_err(pmix_error)
+}
+
+/// Publish metadata, fence, then create an endpoint and unpacked rkey per PE.
+pub fn handshake(
+    client: &PmixClient,
+    transport: &UcxTransport,
+    heap: &SymHeap,
+    size: usize,
+) -> Result<Bootstrap> {
+    if size == 0 {
+        return Err(Error::Usage("bootstrap job size must be nonzero"));
+    }
+    put_bytes(WORKER_ADDR_KEY, transport.packed_address())?;
+    put_bytes(HEAP_RKEY_KEY, heap.packed_rkey())?;
+    let mut base = PmixValueBuilder::new()
+        .uint64(heap.local_base())
+        .build()
+        .map_err(|_| Error::Usage("failed to build heap base value"))?;
+    put_value(PmixScope::Global.to_raw(), HEAP_BASE_KEY, &mut base).map_err(pmix_error)?;
+    pmix::commit().map_err(pmix_error)?;
+    let proc = client.proc().ok_or(Error::NotInitialized)?;
+    pmix::fence(&proc, None).map_err(pmix_error)?;
+
+    let mut peer_rkeys = PeerRkeys::default();
+    let mut peers = BTreeMap::new();
+    for pe in 0..size as u32 {
+        let peer_proc = client.proc_with_nspace(pe).map_err(Error::from)?;
+        let address = get_value(&peer_proc, WORKER_ADDR_GET_KEY, None)
+            .map_err(Error::from)?
+            .bytes_copy();
+        let rkey_bytes = get_value(&peer_proc, HEAP_RKEY_GET_KEY, None)
+            .map_err(Error::from)?
+            .bytes_copy();
+        let heap_base = get_value(&peer_proc, HEAP_BASE_GET_KEY, None)
+            .map_err(Error::from)?
+            .uint64();
+        if address.is_empty() || rkey_bytes.len() < 4 || heap_base == 0 {
+            return Err(Error::Internal(
+                "peer published incomplete bootstrap metadata",
+            ));
+        }
+        let remote_address = RemoteWorkerAddress::new(address);
+        let endpoint = transport.create_endpoint(&remote_address)?;
+        let rkey = RemoteKey::unpack(&endpoint, &rkey_bytes).map_err(Error::from)?;
+        peer_rkeys.insert(pe, heap_base, rkey_bytes);
+        peers.insert(
+            pe,
+            PeerConnection {
+                endpoint,
+                rkey,
+                heap_base,
+            },
+        );
+    }
+    Ok(Bootstrap { peer_rkeys, peers })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keys_are_nul_free_content_and_nul_terminated_for_get() {
+        for (put, get) in [
+            (WORKER_ADDR_KEY, WORKER_ADDR_GET_KEY),
+            (HEAP_RKEY_KEY, HEAP_RKEY_GET_KEY),
+            (HEAP_BASE_KEY, HEAP_BASE_GET_KEY),
+        ] {
+            assert!(!put.to_bytes().contains(&0));
+            assert_eq!(get.last(), Some(&0));
+            assert_eq!(&get[..get.len() - 1], put.to_bytes());
+        }
+    }
+
+    #[test]
+    fn framed_rkey_roundtrip_is_preserved_in_peer_map() {
+        let framed = [3, 0, 0, 0, 9, 8, 7];
+        let mut peers = PeerRkeys::default();
+        peers.insert(1, 0x1000, framed.to_vec());
+        assert_eq!(peers.get(1).unwrap().rkey, framed);
+    }
+
+    #[test]
+    #[ignore = "requires DVM-launched process"]
+    fn dvm_exchanges_worker_heap_metadata() {
+        let client = PmixClient::connect_new(None).expect("PMIx init");
+        let transport = UcxTransport::new(2).expect("UCX worker");
+        let heap = SymHeap::new(&transport).expect("symmetric heap");
+        let size = client
+            .proc_with_nspace(pmix::RANK_WILDCARD)
+            .ok()
+            .and_then(|proc| get_value(&proc, pmix::JOB_SIZE, None).ok())
+            .map(|value| value.uint32() as usize)
+            .unwrap_or(2);
+        let result = handshake(&client, &transport, &heap, size).expect("bootstrap handshake");
+        assert_eq!(result.peers.len(), size);
+        assert!(result.peers.values().all(|peer| peer.heap_base != 0));
+        client.disconnect(None).expect("PMIx finalize");
+    }
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -19,8 +19,10 @@ use crate::rma::UcxTransport;
 use crate::symheap::SymHeap;
 
 struct ShmemState {
-    // Fields are dropped in declaration order. Keep the heap before transport
-    // so its UCX MemHandle is unmapped while the owning context is alive.
+    // Fields are dropped in declaration order. Drop peer UCX handles first,
+    // then the heap, and finally the transport that owns their worker/context.
+    #[allow(dead_code)]
+    peers: std::collections::BTreeMap<u32, PeerConnection>,
     #[allow(dead_code)]
     heap: SymHeap,
     #[allow(dead_code)]
@@ -30,8 +32,6 @@ struct ShmemState {
     size: usize,
     #[allow(dead_code)]
     peer_rkeys: crate::symheap::PeerRkeys,
-    #[allow(dead_code)]
-    peers: std::collections::BTreeMap<u32, PeerConnection>,
 }
 
 static STATE: OnceLock<Mutex<Option<ShmemState>>> = OnceLock::new();
@@ -102,13 +102,13 @@ pub fn init() -> Result<()> {
 
     let crate::bootstrap::Bootstrap { peer_rkeys, peers } = bootstrap;
     *state = Some(ShmemState {
+        peers,
         heap,
         transport,
         client,
         rank,
         size,
         peer_rkeys,
-        peers,
     });
     Ok(())
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -13,6 +13,7 @@ use std::sync::{Mutex, OnceLock};
 
 use pmix::{get_value, PmixClient, RANK_WILDCARD};
 
+use crate::bootstrap::{handshake, PeerConnection};
 use crate::error::{Error, Result};
 use crate::rma::UcxTransport;
 use crate::symheap::SymHeap;
@@ -27,6 +28,10 @@ struct ShmemState {
     client: PmixClient,
     rank: u32,
     size: usize,
+    #[allow(dead_code)]
+    peer_rkeys: crate::symheap::PeerRkeys,
+    #[allow(dead_code)]
+    peers: std::collections::BTreeMap<u32, PeerConnection>,
 }
 
 static STATE: OnceLock<Mutex<Option<ShmemState>>> = OnceLock::new();
@@ -87,12 +92,23 @@ pub fn init() -> Result<()> {
         ));
     };
 
+    let bootstrap = match handshake(&client, &transport, &heap, size) {
+        Ok(bootstrap) => bootstrap,
+        Err(error) => {
+            let _ = client.disconnect(None);
+            return Err(error);
+        }
+    };
+
+    let crate::bootstrap::Bootstrap { peer_rkeys, peers } = bootstrap;
     *state = Some(ShmemState {
         heap,
         transport,
         client,
         rank,
         size,
+        peer_rkeys,
+        peers,
     });
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 // the single narrow `SymHeap` Send implementation required by global state;
 // all other library code remains safe Rust.
 
+pub mod bootstrap;
 pub mod error;
 pub mod init;
 pub mod rma;

--- a/src/rma.rs
+++ b/src/rma.rs
@@ -104,6 +104,15 @@ impl UcxTransport {
     pub fn packed_address(&self) -> &[u8] {
         &self.packed_address
     }
+
+    pub(crate) fn create_endpoint(
+        &self,
+        address: &RemoteWorkerAddress,
+    ) -> std::result::Result<ep::Ep, Error> {
+        self.worker
+            .create_ep(ep::ParamsBuilder::new().address(address).build())
+            .map_err(Error::from)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- exchange UCX worker addresses, framed heap rkeys, and heap bases through PMIx
- create per-peer endpoints and unpack RemoteKeys after commit/fence
- retain peer metadata and document the bootstrap sequence

## Validation
- `PMIX_PREFIX=/home/bzf/pmix-env/openpmix-6.1.0 cargo check --lib`
- `PMIX_PREFIX=/home/bzf/pmix-env/openpmix-6.1.0 cargo clippy --lib -- -D warnings`
- `PMIX_PREFIX=/home/bzf/pmix-env/openpmix-6.1.0 cargo test --tests`
- collectives feature check with the requested UCC environment

DVM integration test is ignored locally and requires `prterun`.

Closes #5