### PR TITLE
feat(rma): implement typed and bulk put/get

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -21,6 +21,7 @@ The mapping mirrors how `osss-ucx/src/shmemc/ucx/*` wires the same three C libra
 | `shmem_my_pe` / `shmem_n_pes` | `init::my_pe()` / `init::n_pes()` | PMIx rank / universe size |
 | `shmem_malloc` / `shmem_free` | `symheap::SymAlloc::{malloc,free}` | Vendored jemalloc pool + UCX `MemHandle::map` / unmap |
 | `shmem_<t>_put` / `shmem_<t>_get` | `rma::put<T>` / `rma::get<T>` | UCX `rma_put` / `rma_get` |
+| `shmem_putmem` / `shmem_getmem` | `rma::putmem` / `rma::getmem` | UCX byte RMA |
 | `shmem_atomic_*` / fetch ops | `rma::atomic_*` | UCX `amo_*64` (+ `reply_buffer`) |
 | `shmem_fence` / `shmem_quiet` | `rma::fence()` / `rma::quiet()` | `ucp_ep_fence_nbx` / `ucp_ep_flush_nbx` |
 | `shmem_barrier*` / collectives | `coll::barrier` / `coll::*` | UCC team + collective builders |
@@ -60,6 +61,11 @@ OSSS-UCX's `comms.c` `translate_address` / `get_remote_key_and_addr` flow:
   remote pointer for a target PE, computed as `peer_heap_base + (local_address -
   local_heap_base)` so every PE preserves the same virtual offset.
 - `rma::put/get` pass this `u64` plus the peer's unpacked `RemoteKey` to UCX.
+
+Typed RMA supports the ten scalar `Pod` types (`u8/i8/u16/i16/u32/i32/u64/i64`
+and `f32/f64`) using native-endian byte encoding. Safe wrappers wait for UCX
+requests with the serialized worker progress loop and free them; `get` never
+reads its destination buffer before completion. Empty operations are no-ops.
 
 Application code cannot build a `SymPtr` from a raw pointer; only `SymAlloc`
 produces them, and only the crate converts them to remote addresses.

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::BTreeMap, ffi::CStr};
 
-use pmix::{get_value, put_value, PmixClient, PmixScope, PmixValueBuilder};
+use pmix::{PmixClient, PmixScope, PmixValueBuilder, get_value, put_value};
 use ucx_sys::{ep::Ep, rma::RemoteKey, worker::RemoteWorkerAddress};
 
 use crate::{
@@ -20,10 +20,8 @@ const HEAP_RKEY_GET_KEY: &[u8] = b"shmem.heap.rkey\0";
 const HEAP_BASE_GET_KEY: &[u8] = b"shmem.heap.base\0";
 
 pub struct PeerConnection {
-    #[allow(dead_code)]
-    endpoint: Ep,
-    #[allow(dead_code)]
-    rkey: RemoteKey,
+    pub(crate) endpoint: Ep,
+    pub(crate) rkey: RemoteKey,
     pub heap_base: u64,
 }
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -11,22 +11,22 @@
 
 use std::sync::{Mutex, OnceLock};
 
-use pmix::{get_value, PmixClient, RANK_WILDCARD};
+use pmix::{PmixClient, RANK_WILDCARD, get_value};
 
-use crate::bootstrap::{handshake, PeerConnection};
+use crate::bootstrap::{PeerConnection, handshake};
 use crate::error::{Error, Result};
 use crate::rma::UcxTransport;
 use crate::symheap::SymHeap;
 
-struct ShmemState {
+pub(crate) struct ShmemState {
     // Fields are dropped in declaration order. Drop peer UCX handles first,
     // then the heap, and finally the transport that owns their worker/context.
     #[allow(dead_code)]
-    peers: std::collections::BTreeMap<u32, PeerConnection>,
+    pub(crate) peers: std::collections::BTreeMap<u32, PeerConnection>,
     #[allow(dead_code)]
     heap: SymHeap,
     #[allow(dead_code)]
-    transport: UcxTransport,
+    pub(crate) transport: UcxTransport,
     client: PmixClient,
     rank: u32,
     size: usize,
@@ -44,6 +44,15 @@ fn lock_state() -> Result<std::sync::MutexGuard<'static, Option<ShmemState>>> {
     state()
         .lock()
         .map_err(|_| Error::Internal("lifecycle state lock poisoned"))
+}
+
+pub(crate) fn with_state<F, T>(operation: F) -> Result<T>
+where
+    F: FnOnce(&ShmemState) -> Result<T>,
+{
+    let state = lock_state()?;
+    let state = state.as_ref().ok_or(Error::NotInitialized)?;
+    operation(state)
 }
 
 /// Initialize the OpenSHMEM process and cache its PE identity.

--- a/src/rma.rs
+++ b/src/rma.rs
@@ -18,6 +18,7 @@ use ucx_sys::context::Context;
 use ucx_sys::ep;
 use ucx_sys::ucs_thread_mode_t;
 use ucx_sys::worker::{MtWorker, RemoteWorkerAddress};
+use ucx_sys::{Request, RequestParamBuilder};
 
 use crate::error::{Error, Result};
 
@@ -113,6 +114,13 @@ impl UcxTransport {
             .create_ep(ep::ParamsBuilder::new().address(address).build())
             .map_err(Error::from)
     }
+
+    pub(crate) fn wait_request(&self, request: &Request) -> Result<()> {
+        match self.worker.wait_request(request).map_err(Error::from)? {
+            true => Ok(()),
+            false => Err(Error::Internal("UCX request completion timed out")),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -134,12 +142,147 @@ mod tests {
     }
 }
 
-/// A typed put, mirroring `shmem_<type>_put` (implemented in a later phase).
-pub fn put<T: Copy>(_dst_pe: i32, _src: &[T], _dst_offset: usize) {
-    todo!("issue: UCX rma_put via per-PE endpoint")
+/// Plain-old-data supported by the typed RMA interface.
+pub trait Pod: Copy + Sized {
+    const SIZE: usize;
+    fn encode(self, dst: &mut Vec<u8>);
+    fn decode(src: &[u8]) -> Result<Self>;
 }
 
-/// A typed get, mirroring `shmem_<type>_get` (implemented in a later phase).
-pub fn get<T: Copy>(_src_pe: i32, _src_offset: usize, _len: usize) -> Vec<T> {
-    todo!("issue: UCX rma_get via per-PE endpoint")
+macro_rules! pod_types {
+    ($($ty:ty => $size:expr),+ $(,)?) => {$ (
+        impl Pod for $ty {
+            const SIZE: usize = $size;
+            fn encode(self, dst: &mut Vec<u8>) { dst.extend_from_slice(&self.to_ne_bytes()); }
+            fn decode(src: &[u8]) -> Result<Self> {
+                let bytes: [u8; $size] = src.try_into().map_err(|_| Error::Internal("invalid typed RMA byte count"))?;
+                Ok(<$ty>::from_ne_bytes(bytes))
+            }
+        }
+    )+ };
+}
+
+pod_types!(u8 => 1, i8 => 1, u16 => 2, i16 => 2, u32 => 4, i32 => 4,
+           u64 => 8, i64 => 8, f32 => 4, f64 => 8);
+
+fn peer_and_address(
+    state: &crate::init::ShmemState,
+    pe: usize,
+    offset: usize,
+    len: usize,
+) -> Result<(&crate::bootstrap::PeerConnection, u64)> {
+    let pe = u32::try_from(pe).map_err(|_| Error::Usage("PE number is out of range"))?;
+    let peer = state
+        .peers
+        .get(&pe)
+        .ok_or(Error::Usage("PE number is not in the job"))?;
+    let offset = u64::try_from(offset).map_err(|_| Error::Usage("RMA offset is out of range"))?;
+    let address = peer
+        .heap_base
+        .checked_add(offset)
+        .ok_or(Error::Usage("RMA address overflow"))?;
+    offset
+        .checked_add(u64::try_from(len).map_err(|_| Error::Usage("RMA length is out of range"))?)
+        .ok_or(Error::Usage("RMA range overflow"))?;
+    Ok((peer, address))
+}
+
+/// Put raw bytes in the destination PE's symmetric heap.
+///
+/// UCX may return an asynchronous request. This safe wrapper waits for that
+/// request before returning, because the source is borrowed; future `quiet`
+/// support can provide deferred OpenSHMEM completion for owned buffers.
+pub fn putmem(dst_pe: usize, bytes: &[u8], dst_offset: usize) -> Result<()> {
+    crate::init::with_state(|state| {
+        let (peer, address) = peer_and_address(state, dst_pe, dst_offset, bytes.len())?;
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        let params = RequestParamBuilder::new().build();
+        let request = peer
+            .endpoint
+            .rma_put(bytes, address, &peer.rkey, &params)
+            .map_err(Error::from)?;
+        if let Some(request) = request {
+            state.transport.wait_request(&request)?;
+            request.free();
+        }
+        Ok(())
+    })
+}
+
+/// Get raw bytes, decoding only after UCX request completion.
+pub fn getmem(src_pe: usize, src_offset: usize, len: usize) -> Result<Vec<u8>> {
+    crate::init::with_state(|state| {
+        let (peer, address) = peer_and_address(state, src_pe, src_offset, len)?;
+        let mut bytes = vec![0_u8; len];
+        if bytes.is_empty() {
+            return Ok(bytes);
+        }
+        let params = RequestParamBuilder::new().build();
+        let request = peer
+            .endpoint
+            .rma_get(&mut bytes, address, &peer.rkey, &params)
+            .map_err(Error::from)?;
+        if let Some(request) = request {
+            state.transport.wait_request(&request)?;
+            request.free();
+        }
+        Ok(bytes)
+    })
+}
+
+/// Put typed POD values in native-endian representation.
+pub fn put<T: Pod>(dst_pe: usize, src: &[T], dst_offset: usize) -> Result<()> {
+    let capacity = src
+        .len()
+        .checked_mul(T::SIZE)
+        .ok_or(Error::Usage("typed RMA length overflow"))?;
+    let mut bytes = Vec::with_capacity(capacity);
+    for &value in src {
+        value.encode(&mut bytes);
+    }
+    putmem(dst_pe, &bytes, dst_offset)
+}
+
+/// Get typed POD values after the underlying UCX request has completed.
+pub fn get<T: Pod>(src_pe: usize, src_offset: usize, len_elems: usize) -> Result<Vec<T>> {
+    let len = len_elems
+        .checked_mul(T::SIZE)
+        .ok_or(Error::Usage("typed RMA length overflow"))?;
+    getmem(src_pe, src_offset, len)?
+        .chunks_exact(T::SIZE)
+        .map(T::decode)
+        .collect()
+}
+
+#[cfg(test)]
+mod pod_tests {
+    use super::*;
+
+    fn roundtrip<T: Pod + PartialEq + std::fmt::Debug>(value: T) {
+        let mut bytes = Vec::new();
+        value.encode(&mut bytes);
+        assert_eq!(T::decode(&bytes).unwrap(), value);
+        assert_eq!(bytes.len(), T::SIZE);
+    }
+
+    #[test]
+    fn pod_covers_all_supported_scalar_types() {
+        roundtrip(1_u8);
+        roundtrip(-1_i8);
+        roundtrip(2_u16);
+        roundtrip(-2_i16);
+        roundtrip(3_u32);
+        roundtrip(-3_i32);
+        roundtrip(4_u64);
+        roundtrip(-4_i64);
+        roundtrip(1.5_f32);
+        roundtrip(-2.5_f64);
+    }
+
+    #[test]
+    fn typed_length_overflow_is_rejected_before_state_lookup() {
+        assert!(matches!(get::<u64>(0, 0, usize::MAX), Err(Error::Usage(_))));
+    }
 }

--- a/src/rma.rs
+++ b/src/rma.rs
@@ -54,7 +54,7 @@ impl UcxTransport {
     /// serialized by its binding-level mutex so this handle can be retained in
     /// the process-global lifecycle state.
     pub fn new(estimated_num_eps: usize) -> Result<Self> {
-        let features = context::Flags::Tag;
+        let features = context::Flags::Tag | context::Flags::Rma;
         let mut params_builder = context::ParamsBuilder::new();
         params_builder
             .features(features)
@@ -115,10 +115,18 @@ impl UcxTransport {
             .map_err(Error::from)
     }
 
+    /// Wait for a request until UCX reports completion.
+    ///
+    /// The binding's helper has a fixed one-million-round budget. RMA
+    /// operations can legitimately need more progress rounds for large
+    /// transfers, so this wrapper retries that helper while it reports an
+    /// incomplete request instead of treating the budget as a timeout.
     pub(crate) fn wait_request(&self, request: &Request) -> Result<()> {
-        match self.worker.wait_request(request).map_err(Error::from)? {
-            true => Ok(()),
-            false => Err(Error::Internal("UCX request completion timed out")),
+        loop {
+            match self.worker.wait_request(request).map_err(Error::from)? {
+                true => return Ok(()),
+                false => continue,
+            }
         }
     }
 }
@@ -136,9 +144,37 @@ mod tests {
     }
 
     #[test]
-    fn creates_a_self_addressed_endpoint() {
+    fn loopback_rma_put_get_roundtrip_uses_real_completion_path() {
+        use ucx_sys::rma::RemoteKey;
+
         let transport = UcxTransport::new(1).expect("UCX RMA context and worker");
-        let _endpoint = transport.loopback_endpoint().expect("self endpoint");
+        let mut target = vec![0_u8; 4096];
+        let memh = ucx_sys::memh::MemHandle::map_slice(transport.context(), &mut target, 0)
+            .expect("registered heap");
+        let packed_rkey = ucx_sys::rma::RemoteKey::pack(transport.context(), memh.mem_handle())
+            .expect("pack heap rkey");
+        let endpoint = transport.loopback_endpoint().expect("self endpoint");
+        let rkey = RemoteKey::unpack(&endpoint, &packed_rkey).expect("own framed rkey");
+        let params = RequestParamBuilder::new().no_imm_cmpl().build();
+        let source = b"loopback RMA";
+        let mut destination = vec![0_u8; source.len()];
+
+        if let Some(request) = endpoint
+            .rma_put(source, target.as_mut_ptr() as u64, &rkey, &params)
+            .expect("loopback put")
+        {
+            transport.wait_request(&request).expect("put completion");
+            request.free();
+        }
+        if let Some(request) = endpoint
+            .rma_get(&mut destination, target.as_mut_ptr() as u64, &rkey, &params)
+            .expect("loopback get")
+        {
+            transport.wait_request(&request).expect("get completion");
+            request.free();
+        }
+
+        assert_eq!(destination, source);
     }
 }
 


### PR DESCRIPTION
## Summary
- Implement typed `put`/`get` for ten scalar POD types with safe byte encoding.
- Add bulk `putmem`/`getmem` through bootstrapped per-PE UCX endpoints and rkeys.
- Wait for UCX completion before returning borrowed put buffers or get data.
- Document addressing and completion semantics.

## Validation
- `cargo check --lib`
- `cargo clippy --lib -- -D warnings`
- `cargo test --tests`
- `env -u UCC_PREFIX UCC_INCLUDE_DIR=/tmp/emptyinc UCC_LIB_DIR=/home/bzf/lib cargo check --lib --features collectives`

No new unsafe code.

Closes #6