### PR TITLE
feat(collectives): add non-blocking UCC variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ installed and set `UCC_INCLUDE_DIR` and `UCC_LIB_DIR` (or set `UCC_PREFIX`). The
 `ucc` dependency is feature-gated because there is no system
 `pkg-config` UCC entry.
 
+Blocking collectives wait before returning. The feature-gated `coll::*_nb`
+variants return a `CollectiveRequest`; call `test()` to poll or `wait()` to
+drive UCC progress to completion. UCX tag-matching fallback collectives are
+not included yet and remain future work.
+
 The CI checks compile and test the library without requiring a PMIx DVM or
 daemon. DVM-backed integration tests require a PRRTE installation and its
 corresponding `PATH` and `LD_LIBRARY_PATH` exports.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -24,7 +24,7 @@ The mapping mirrors how `osss-ucx/src/shmemc/ucx/*` wires the same three C libra
 | `shmem_putmem` / `shmem_getmem` | `rma::putmem` / `rma::getmem` | UCX byte RMA |
 | `shmem_atomic_*` / fetch ops | `rma::atomic_*` | UCX `amo_*64` (+ `reply_buffer`) |
 | `shmem_fence` / `shmem_quiet` | `rma::fence()` / `rma::quiet()` | `ucp_ep_fence_nbx` / `ucp_ep_flush_nbx` |
-| `shmem_barrier*` / collectives | `coll::barrier` / `coll::*` | UCC team + collective builders |
+| `shmem_barrier*` / collectives | `coll::barrier` / `coll::*` and `coll::*_nb` | UCC team + collective builders |
 
 ## Conventions
 
@@ -48,6 +48,18 @@ framed heap rkey, and heap base, then performs `commit` and a PMIx `fence`
 before any peer `get`. Each peer address creates a UCX endpoint and its complete
 framed rkey is passed to `RemoteKey::unpack`; the framed bytes and base are also
 retained in `PeerRkeys`.
+
+### Non-blocking collectives
+
+The `_nb` APIs expose UCC's existing asynchronous request shape. They retain
+encoded buffers and return `CollectiveRequest`; `test()` polls without waiting
+and `wait()` repeatedly progresses UCC until completion. Typed broadcast and
+reduce copy completed bytes back into their borrowed destinations. `collect_nb`
+returns gathered values through `request.result::<T>()` after completion.
+
+The APIs are available only with `--features collectives`. A UCX tag-matching
+fallback for default builds is deliberately future work, rather than an
+emulated or silently blocking implementation.
 
 ## Symmetric addressing (`SymPtr`)
 

--- a/src/coll.rs
+++ b/src/coll.rs
@@ -1,5 +1,13 @@
-//! UCC-backed blocking collectives, selected at compile time by `collectives`.
-//! UCC team creation uses PMIx for the required out-of-band allgather.
+//! UCC-backed blocking and non-blocking collectives, selected at compile time by
+//! `collectives`. UCC team creation uses PMIx for the required out-of-band
+//! allgather.
+//!
+//! Blocking functions (for example [`barrier`]) post an operation and wait for
+//! completion before returning. The `_nb` variants post the same UCC operation
+//! and return a [`CollectiveRequest`]; callers can poll with [`CollectiveRequest::test`]
+//! or drive progress until completion with [`CollectiveRequest::wait`]. The
+//! non-blocking UCC path is feature-gated; UCX tag-matching fallback collectives
+//! remain future work.
 #![cfg(feature = "collectives")]
 #![allow(unsafe_op_in_unsafe_fn)]
 
@@ -7,7 +15,7 @@ use crate::{
     error::{Error, Result},
     rma::Pod,
 };
-use pmix::{get_value, put_value, PmixScope};
+use pmix::{PmixScope, get_value, put_value};
 use std::{ffi::c_void, ptr};
 use ucc::{
     bindings::{ucc_oob_coll_t, ucc_status_t_UCC_ERR_NO_MESSAGE, ucc_status_t_UCC_OK},
@@ -141,6 +149,94 @@ fn wait(context: &UccContext, mut op: UccCollective) -> Result<()> {
         context.progress();
     }
 }
+/// A posted collective request. The request keeps operation buffers alive until
+/// completion and may be polled with [`Self::test`] or completed with [`Self::wait`].
+type CopyBack = fn(&[u8], *mut u8, usize) -> Result<()>;
+type Destination = (*mut u8, usize, CopyBack);
+
+pub struct CollectiveRequest<'a> {
+    op: Option<UccCollective>,
+    context: UccContext,
+    buffers: Vec<Vec<u8>>,
+    destination: Option<Destination>,
+    result_index: Option<usize>,
+    _borrow: std::marker::PhantomData<&'a mut [u8]>,
+}
+
+impl<'a> CollectiveRequest<'a> {
+    fn new(
+        context: UccContext,
+        op: UccCollective,
+        buffers: Vec<Vec<u8>>,
+        destination: Option<Destination>,
+        result_index: Option<usize>,
+    ) -> Self {
+        Self {
+            op: Some(op),
+            context,
+            buffers,
+            destination,
+            result_index,
+            _borrow: std::marker::PhantomData,
+        }
+    }
+
+    /// Poll without blocking. Returns false while UCC still needs progress.
+    pub fn test(&mut self) -> Result<bool> {
+        let op = self
+            .op
+            .as_ref()
+            .ok_or(Error::Internal("collective request already finalized"))?;
+        let status = unsafe { (*op.request()).status };
+        if status == ucc_status_t_UCC_ERR_NO_MESSAGE {
+            return Ok(false);
+        }
+        if status != ucc_status_t_UCC_OK {
+            return Err(map_ucc(ucc::UccStatus::from_raw(status)));
+        }
+        let mut op = self.op.take().expect("checked above");
+        op.finalize().map_err(map_ucc)?;
+        if let Some((destination, count, decode)) = self.destination {
+            decode(
+                self.buffers
+                    .last()
+                    .ok_or(Error::Internal("missing collective buffer"))?,
+                destination,
+                count,
+            )?;
+        }
+        Ok(true)
+    }
+
+    /// Drive UCC progress until completion.
+    pub fn wait(&mut self) -> Result<()> {
+        while !self.test()? {
+            self.context.progress();
+        }
+        Ok(())
+    }
+
+    /// Read a completed `collect_nb` result.
+    pub fn result<T: Pod>(&self) -> Result<Vec<T>> {
+        if self.op.is_some() {
+            return Err(Error::Usage("collective request is not complete"));
+        }
+        let index = self
+            .result_index
+            .ok_or(Error::Usage("request has no collected result"))?;
+        self.buffers[index]
+            .chunks_exact(T::SIZE)
+            .map(T::decode)
+            .collect()
+    }
+}
+
+fn decode_to<T: Pod>(bytes: &[u8], destination: *mut u8, count: usize) -> Result<()> {
+    // SAFETY: the request retains the exclusive borrow and UCC is complete.
+    let values = unsafe { std::slice::from_raw_parts_mut(destination.cast::<T>(), count) };
+    decode(bytes, values)
+}
+
 fn dtype<T: Pod>() -> u32 {
     T::ucc_datatype().as_raw() as u32
 }
@@ -276,6 +372,142 @@ pub fn reduce<T: Pod>(op: UccReductionOp, values: &mut [T]) -> Result<()> {
     decode(&bytes, values)
 }
 
+/// Post a barrier without waiting for completion.
+pub fn barrier_nb() -> Result<CollectiveRequest<'static>> {
+    crate::init::with_state(|state| {
+        let runtime = state
+            .collectives
+            .as_ref()
+            .ok_or(Error::Internal("collectives are not initialized"))?;
+        let mut stub = vec![0u8];
+        let op = CollectiveBuilder::new(UccCollectiveType::Barrier)
+            .with_inplace(&mut stub)
+            .with_count(1)
+            .init(&runtime.team)
+            .map_err(map_ucc)?;
+        op.post().map_err(map_ucc)?;
+        Ok(CollectiveRequest::new(
+            runtime.context.clone(),
+            op,
+            vec![stub],
+            None,
+            None,
+        ))
+    })
+}
+
+/// Post a typed broadcast without waiting for completion.
+pub fn broadcast_nb<T: Pod>(root: usize, values: &mut [T]) -> Result<CollectiveRequest<'_>> {
+    if values.is_empty() {
+        return Err(Error::Usage("collective buffer must be non-empty"));
+    }
+    let bytes = encode(values)?;
+    let destination = (
+        values.as_mut_ptr().cast::<u8>(),
+        values.len(),
+        decode_to::<T> as fn(&[u8], *mut u8, usize) -> Result<()>,
+    );
+    crate::init::with_state(|state| {
+        let runtime = state
+            .collectives
+            .as_ref()
+            .ok_or(Error::Internal("collectives are not initialized"))?;
+        if root >= runtime.team.size().map_err(map_ucc)? as usize {
+            return Err(Error::Usage("broadcast root is outside the UCC team"));
+        }
+        let mut buffer = bytes;
+        let op = CollectiveBuilder::new(UccCollectiveType::Broadcast)
+            .with_inplace(&mut buffer)
+            .with_count(values.len() as u64)
+            .with_dtype(dtype::<T>())
+            .with_root(root as u64)
+            .init(&runtime.team)
+            .map_err(map_ucc)?;
+        op.post().map_err(map_ucc)?;
+        Ok(CollectiveRequest::new(
+            runtime.context.clone(),
+            op,
+            vec![buffer],
+            Some(destination),
+            None,
+        ))
+    })
+}
+
+/// Post an equal-sized typed allgather without waiting for completion.
+pub fn collect_nb<T: Pod>(values: &[T]) -> Result<CollectiveRequest<'static>> {
+    if values.is_empty() {
+        return Err(Error::Usage("collective contribution must be non-empty"));
+    }
+    crate::init::with_state(|state| {
+        let runtime = state
+            .collectives
+            .as_ref()
+            .ok_or(Error::Internal("collectives are not initialized"))?;
+        let send = encode(values)?;
+        let ranks = runtime.team.size().map_err(map_ucc)? as usize;
+        let recv_len = send
+            .len()
+            .checked_mul(ranks)
+            .ok_or(Error::Usage("collective receive buffer overflow"))?;
+        let mut recv = vec![0u8; recv_len];
+        let op = CollectiveBuilder::new(UccCollectiveType::Allgather)
+            .with_src(&send)
+            .with_dst(&mut recv)
+            .with_count(values.len() as u64)
+            .with_dtype(dtype::<T>())
+            .init(&runtime.team)
+            .map_err(map_ucc)?;
+        op.post().map_err(map_ucc)?;
+        Ok(CollectiveRequest::new(
+            runtime.context.clone(),
+            op,
+            vec![send, recv],
+            None,
+            Some(1),
+        ))
+    })
+}
+
+/// Post an in-place typed allreduce without waiting for completion.
+pub fn reduce_nb<T: Pod>(op: UccReductionOp, values: &mut [T]) -> Result<CollectiveRequest<'_>> {
+    if values.is_empty() {
+        return Err(Error::Usage("collective buffer must be non-empty"));
+    }
+    if !T::reduction_supported(op) {
+        return Err(Error::Usage(
+            "reduction operation is not supported for this POD type",
+        ));
+    }
+    let mut bytes = encode(values)?;
+    let destination = (
+        values.as_mut_ptr().cast::<u8>(),
+        values.len(),
+        decode_to::<T> as fn(&[u8], *mut u8, usize) -> Result<()>,
+    );
+    crate::init::with_state(|state| {
+        let runtime = state
+            .collectives
+            .as_ref()
+            .ok_or(Error::Internal("collectives are not initialized"))?;
+        let operation = CollectiveBuilder::new(UccCollectiveType::Allreduce)
+            .with_inplace(&mut bytes)
+            .with_count(values.len() as u64)
+            .with_dtype(dtype::<T>())
+            .with_reduction_op(op)
+            .init(&runtime.team)
+            .map_err(map_ucc)?;
+        operation.post().map_err(map_ucc)?;
+        Ok(CollectiveRequest::new(
+            runtime.context.clone(),
+            operation,
+            vec![bytes],
+            Some(destination),
+            None,
+        ))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -285,6 +517,11 @@ mod tests {
         let _: fn(usize, &mut [u8]) -> Result<()> = broadcast;
         let _: fn(&[u8]) -> Result<Vec<u8>> = collect;
         let _: fn(UccReductionOp, &mut [u8]) -> Result<()> = reduce;
+        let _: fn() -> Result<CollectiveRequest<'static>> = barrier_nb;
+        let _: fn(usize, &mut [u8]) -> Result<CollectiveRequest<'_>> = broadcast_nb;
+        let _: fn(&[u8]) -> Result<CollectiveRequest<'static>> = collect_nb;
+        let _: fn(UccReductionOp, &mut [u8]) -> Result<CollectiveRequest<'_>> = reduce_nb;
+        let _: fn(&CollectiveRequest<'static>) -> Result<Vec<u8>> = CollectiveRequest::result::<u8>;
     }
 
     #[test]
@@ -297,6 +534,20 @@ mod tests {
     fn execution_requires_dvm() {
         crate::init::init().unwrap();
         barrier().unwrap();
+        let mut barrier_request = barrier_nb().unwrap();
+        barrier_request.wait().unwrap();
+        let mut broadcast_values = [0u8; 1];
+        let mut broadcast_request = broadcast_nb(0, &mut broadcast_values).unwrap();
+        broadcast_request.wait().unwrap();
+        let mut reduce_values = [1u8; 1];
+        let mut reduce_request = reduce_nb(UccReductionOp::Sum, &mut reduce_values).unwrap();
+        reduce_request.wait().unwrap();
+        let mut collect_request = collect_nb(&[1u8]).unwrap();
+        collect_request.wait().unwrap();
+        assert_eq!(
+            collect_request.result::<u8>().unwrap().len(),
+            crate::init::n_pes().unwrap()
+        );
         crate::init::finalize().unwrap();
     }
 }

--- a/src/coll.rs
+++ b/src/coll.rs
@@ -15,7 +15,7 @@ use crate::{
     error::{Error, Result},
     rma::Pod,
 };
-use pmix::{PmixScope, get_value, put_value};
+use pmix::{get_value, put_value, PmixScope};
 use std::{ffi::c_void, ptr};
 use ucc::{
     bindings::{ucc_oob_coll_t, ucc_status_t_UCC_ERR_NO_MESSAGE, ucc_status_t_UCC_OK},
@@ -101,8 +101,10 @@ pub(crate) struct Runtime {
     _lib: UccLib,
     _oob: Box<OobState>,
 }
-// SAFETY: Every collective operation enters `with_state`, which holds the
+// SAFETY: Blocking collective operations enter `with_state`, which holds the
 // lifecycle mutex for the entire operation and therefore serializes UCC ops.
+// Non-blocking request progress/testing runs after posting and outside that
+// mutex; callers must use `_nb` requests from a single thread for now.
 unsafe impl Send for Runtime {}
 
 impl Runtime {
@@ -182,13 +184,16 @@ impl<'a> CollectiveRequest<'a> {
     }
 
     /// Poll without blocking. Returns false while UCC still needs progress.
+    ///
+    /// Non-blocking requests are currently intended for single-threaded use:
+    /// this method drives progress outside the lifecycle mutex.
     pub fn test(&mut self) -> Result<bool> {
-        let op = self
-            .op
-            .as_ref()
-            .ok_or(Error::Internal("collective request already finalized"))?;
+        let Some(op) = self.op.as_ref() else {
+            return Ok(true);
+        };
         let status = unsafe { (*op.request()).status };
         if status == ucc_status_t_UCC_ERR_NO_MESSAGE {
+            self.context.progress();
             return Ok(false);
         }
         if status != ucc_status_t_UCC_OK {
@@ -210,9 +215,7 @@ impl<'a> CollectiveRequest<'a> {
 
     /// Drive UCC progress until completion.
     pub fn wait(&mut self) -> Result<()> {
-        while !self.test()? {
-            self.context.progress();
-        }
+        while !self.test()? {}
         Ok(())
     }
 


### PR DESCRIPTION
Closes #12

## Summary
- expose CollectiveRequest with test() and wait() over the existing UCC asynchronous request API
- add barrier_nb, broadcast_nb, collect_nb, and reduce_nb
- retain operation buffers safely and copy typed results back after completion
- document blocking/non-blocking usage and the deliberate scope boundary

## Validation
All requested gates pass locally. The default test suite reports 17 passed, 0 failed, 3 ignored. Feature-gated checks use the requested PMIx/UCC environment; no DVM or UCC execution was attempted.

## Scope decision
This PR implements the UCC path only. UCX tag-matching fallback collectives are not included because a complete fallback for all variants is larger than this focused exposure of UCC's already non-blocking API; it is documented as future work. No fake fallback or silently blocking default-build API was added.