### PR TITLE
feat(examples): add Phase 5 integration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ export LD_LIBRARY_PATH="$PMIX_PREFIX/lib:${LD_LIBRARY_PATH:-}"
 
 Collectives are optional: enable `--features collectives` when UCC 1.8.0 is
 installed and set `UCC_INCLUDE_DIR` and `UCC_LIB_DIR` (or set `UCC_PREFIX`). The
-`ucc` dependency is feature-gated because there is no system
-`pkg-config` UCC entry.
+`ucc` dependency is feature-gated because there is no system `pkg-config` UCC
+entry.
 
 Blocking collectives wait before returning. The feature-gated `coll::*_nb`
 variants return a `CollectiveRequest`; call `test()` to poll or `wait()` to
@@ -28,5 +28,23 @@ not included yet and remain future work.
 The CI checks compile and test the library without requiring a PMIx DVM or
 daemon. DVM-backed integration tests require a PRRTE installation and its
 corresponding `PATH` and `LD_LIBRARY_PATH` exports.
+
+## Examples
+
+Both examples require a live PMIx/PRRTE DVM and are intended for multi-PE runs.
+See [docs/RDMA-RUNNING.md](docs/RDMA-RUNNING.md) for the environment checklist.
+
+```bash
+# Two-PE symmetric RMA put/get demonstration
+prterun -np 2 -x PMIX_SIZE=2 cargo run --example ping_put_get
+
+# N-PE UCC barrier demonstration
+prterun -np 4 -x PMIX_SIZE=4 cargo run --features collectives --example barrier
+```
+
+The examples deliberately fail with a clear message when launched with the
+wrong PE count or without the required `collectives` feature. Build them
+without a DVM using `cargo check --examples`; use the collectives feature for
+`barrier`'s full implementation.
 
 See [docs/DESIGN.md](docs/DESIGN.md) for architecture and the implementation roadmap. For the manual multi-PE procedure on RDMA-capable hardware, see [docs/RDMA-RUNNING.md](docs/RDMA-RUNNING.md).

--- a/examples/barrier.rs
+++ b/examples/barrier.rs
@@ -1,0 +1,31 @@
+//! Run with a live PRRTE/PMIx DVM, for example:
+//! `prterun -np 4 -x PMIX_SIZE=4 cargo run --features collectives --example barrier`
+//! See docs/RDMA-RUNNING.md for the required DVM and UCC setup.
+
+#[cfg(feature = "collectives")]
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("barrier failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(feature = "collectives")]
+fn run() -> openshmem::error::Result<()> {
+    openshmem::init::init()?;
+    let rank = openshmem::init::my_pe()?;
+    let size = openshmem::init::n_pes()?;
+    println!("PE {rank}/{size} entering barrier");
+    let barrier_result = openshmem::coll::barrier();
+    let finalize_result = openshmem::init::finalize();
+    barrier_result?;
+    finalize_result?;
+    println!("PE {rank}/{size} passed barrier");
+    Ok(())
+}
+
+#[cfg(not(feature = "collectives"))]
+fn main() {
+    eprintln!("barrier example requires the `collectives` feature");
+    std::process::exit(1);
+}

--- a/examples/barrier.rs
+++ b/examples/barrier.rs
@@ -17,10 +17,9 @@ fn run() -> openshmem::error::Result<()> {
     let size = openshmem::init::n_pes()?;
     println!("PE {rank}/{size} entering barrier");
     let barrier_result = openshmem::coll::barrier();
-    let finalize_result = openshmem::init::finalize();
     barrier_result?;
-    finalize_result?;
     println!("PE {rank}/{size} passed barrier");
+    openshmem::init::finalize()?;
     Ok(())
 }
 

--- a/examples/ping_put_get.rs
+++ b/examples/ping_put_get.rs
@@ -22,7 +22,7 @@ fn run() -> openshmem::error::Result<()> {
     }
 
     let buffer = init::malloc(std::mem::size_of::<u64>())?;
-    let offset = buffer.offset_from(init::heap_base()?);
+    let offset = buffer.offset_from(init::heap_base()?)?;
     if rank == 0 {
         rma::put(TARGET_PE, &[VALUE], offset + VALUE_OFFSET)?;
         rma::fence()?;
@@ -30,22 +30,17 @@ fn run() -> openshmem::error::Result<()> {
         println!("PE 0 put {VALUE:#x} to PE 1");
     } else {
         let deadline = Instant::now() + GET_TIMEOUT;
-        let received = loop {
-            let received = rma::get::<u64>(0, offset + VALUE_OFFSET, 1)?;
+        loop {
+            let received = rma::get::<u64>(rank, offset + VALUE_OFFSET, 1)?;
             if received.as_slice() == [VALUE] {
-                break received;
+                break;
             }
             if Instant::now() >= deadline {
                 return Err(openshmem::error::Error::Internal(
-                    "timed out waiting for PE 0's value",
+                    "timed out waiting for PE 1's value",
                 ));
             }
             std::thread::yield_now();
-        };
-        if received.as_slice() != [VALUE] {
-            return Err(openshmem::error::Error::Internal(
-                "PE 1 received an unexpected value",
-            ));
         }
         println!("PE 1 got and verified {VALUE:#x}");
     }

--- a/examples/ping_put_get.rs
+++ b/examples/ping_put_get.rs
@@ -1,0 +1,52 @@
+//! Run with a live PRRTE/PMIx DVM, for example:
+//! `prterun -np 2 -x PMIX_SIZE=2 cargo run --example ping_put_get`
+//! See docs/RDMA-RUNNING.md for the required DVM and UCX setup.
+
+use openshmem::{init, rma};
+
+const TARGET_PE: usize = 1;
+const VALUE_OFFSET: usize = 0;
+const VALUE: u64 = 0x5049_4e47_2d52_4d41;
+
+fn run() -> openshmem::error::Result<()> {
+    init::init()?;
+    let rank = init::my_pe()? as usize;
+    let size = init::n_pes()?;
+    if size != 2 {
+        return Err(openshmem::error::Error::Usage(
+            "ping_put_get requires exactly two PEs",
+        ));
+    }
+
+    let buffer = init::malloc(std::mem::size_of::<u64>())?;
+    let offset = buffer.offset_from(init::heap_base()?);
+    if rank == 0 {
+        rma::put(TARGET_PE, &[VALUE], offset + VALUE_OFFSET)?;
+        rma::fence()?;
+        rma::quiet_pe(TARGET_PE)?;
+        println!("PE 0 put {VALUE:#x} to PE 1");
+    } else {
+        let received = rma::get::<u64>(0, offset + VALUE_OFFSET, 1)?;
+        if received.as_slice() != [VALUE] {
+            return Err(openshmem::error::Error::Internal(
+                "PE 1 received an unexpected value",
+            ));
+        }
+        println!("PE 1 got and verified {VALUE:#x}");
+    }
+    init::free(buffer)?;
+    Ok(())
+}
+
+fn main() {
+    let result = run();
+    let finalize_result = init::finalize();
+    if let Err(error) = result {
+        eprintln!("ping_put_get failed: {error}");
+        std::process::exit(1);
+    }
+    if let Err(error) = finalize_result {
+        eprintln!("finalize failed: {error}");
+        std::process::exit(1);
+    }
+}

--- a/examples/ping_put_get.rs
+++ b/examples/ping_put_get.rs
@@ -1,0 +1,67 @@
+//! Run with a live PRRTE/PMIx DVM, for example:
+//! `prterun -np 2 -x PMIX_SIZE=2 cargo run --example ping_put_get`
+//! See docs/RDMA-RUNNING.md for the required DVM and UCX setup.
+
+use std::time::{Duration, Instant};
+
+use openshmem::{init, rma};
+
+const TARGET_PE: usize = 1;
+const VALUE_OFFSET: usize = 0;
+const VALUE: u64 = 0x5049_4e47_2d52_4d41;
+const GET_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn run() -> openshmem::error::Result<()> {
+    init::init()?;
+    let rank = init::my_pe()? as usize;
+    let size = init::n_pes()?;
+    if size != 2 {
+        return Err(openshmem::error::Error::Usage(
+            "ping_put_get requires exactly two PEs",
+        ));
+    }
+
+    let buffer = init::malloc(std::mem::size_of::<u64>())?;
+    let offset = buffer.offset_from(init::heap_base()?);
+    if rank == 0 {
+        rma::put(TARGET_PE, &[VALUE], offset + VALUE_OFFSET)?;
+        rma::fence()?;
+        rma::quiet_pe(TARGET_PE)?;
+        println!("PE 0 put {VALUE:#x} to PE 1");
+    } else {
+        let deadline = Instant::now() + GET_TIMEOUT;
+        let received = loop {
+            let received = rma::get::<u64>(0, offset + VALUE_OFFSET, 1)?;
+            if received.as_slice() == [VALUE] {
+                break received;
+            }
+            if Instant::now() >= deadline {
+                return Err(openshmem::error::Error::Internal(
+                    "timed out waiting for PE 0's value",
+                ));
+            }
+            std::thread::yield_now();
+        };
+        if received.as_slice() != [VALUE] {
+            return Err(openshmem::error::Error::Internal(
+                "PE 1 received an unexpected value",
+            ));
+        }
+        println!("PE 1 got and verified {VALUE:#x}");
+    }
+    init::free(buffer)?;
+    Ok(())
+}
+
+fn main() {
+    let result = run();
+    let finalize_result = init::finalize();
+    if let Err(error) = result {
+        eprintln!("ping_put_get failed: {error}");
+        std::process::exit(1);
+    }
+    if let Err(error) = finalize_result {
+        eprintln!("finalize failed: {error}");
+        std::process::exit(1);
+    }
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -163,6 +163,31 @@ pub fn n_pes() -> Result<usize> {
         .ok_or(Error::NotInitialized)
 }
 
+/// Allocate a symmetric buffer from this PE's registered heap.
+pub fn malloc(size: usize) -> Result<crate::symheap::SymPtr> {
+    let mut state = lock_state()?;
+    state
+        .as_mut()
+        .ok_or(Error::NotInitialized)?
+        .heap
+        .malloc(size)
+}
+
+pub fn heap_base() -> Result<u64> {
+    let state = lock_state()?;
+    Ok(state
+        .as_ref()
+        .ok_or(Error::NotInitialized)?
+        .heap
+        .local_base())
+}
+
+/// Free a buffer previously returned by [`malloc`].
+pub fn free(ptr: crate::symheap::SymPtr) -> Result<()> {
+    let mut state = lock_state()?;
+    state.as_mut().ok_or(Error::NotInitialized)?.heap.free(ptr)
+}
+
 /// Finalize the PMIx session.
 ///
 /// Finalization is idempotent. The stored client is explicitly disconnected

--- a/src/init.rs
+++ b/src/init.rs
@@ -173,6 +173,7 @@ pub fn malloc(size: usize) -> Result<crate::symheap::SymPtr> {
         .malloc(size)
 }
 
+/// Return this process's symmetric heap base address.
 pub fn heap_base() -> Result<u64> {
     let state = lock_state()?;
     Ok(state

--- a/src/symheap.rs
+++ b/src/symheap.rs
@@ -22,16 +22,23 @@ const ALIGNMENT: usize = 8;
 pub struct SymPtr(pub(crate) usize);
 
 impl SymPtr {
+    /// Return this allocation's byte offset from a symmetric heap base.
+    pub fn offset_from(self, local_base: u64) -> usize {
+        self.0
+            .checked_sub(local_base as usize)
+            .expect("pointer belongs to heap")
+    }
+
     /// Return the virtual offset from a local heap base.
     #[allow(dead_code)]
-    pub(crate) fn offset_from(self, local_base: u64) -> u64 {
-        (self.0 as u64).wrapping_sub(local_base)
+    pub(crate) fn offset_from_u64(self, local_base: u64) -> u64 {
+        self.offset_from(local_base) as u64
     }
 
     /// Translate this allocation's offset to a target PE's heap address.
     #[allow(dead_code)]
     pub(crate) fn to_remote_addr(self, local_base: u64, peer_base: u64) -> u64 {
-        peer_base.wrapping_add(self.offset_from(local_base))
+        peer_base.wrapping_add(self.offset_from_u64(local_base))
     }
 }
 

--- a/src/symheap.rs
+++ b/src/symheap.rs
@@ -23,22 +23,26 @@ pub struct SymPtr(pub(crate) usize);
 
 impl SymPtr {
     /// Return this allocation's byte offset from a symmetric heap base.
-    pub fn offset_from(self, local_base: u64) -> usize {
+    ///
+    /// Returns an error when `local_base` is above the allocation address.
+    pub fn offset_from(self, local_base: u64) -> Result<usize> {
         self.0
             .checked_sub(local_base as usize)
-            .expect("pointer belongs to heap")
+            .ok_or(Error::Usage("pointer is below symmetric heap base"))
     }
 
     /// Return the virtual offset from a local heap base.
     #[allow(dead_code)]
-    pub(crate) fn offset_from_u64(self, local_base: u64) -> u64 {
-        self.offset_from(local_base) as u64
+    pub(crate) fn offset_from_u64(self, local_base: u64) -> Result<u64> {
+        self.offset_from(local_base).map(|offset| offset as u64)
     }
 
     /// Translate this allocation's offset to a target PE's heap address.
     #[allow(dead_code)]
-    pub(crate) fn to_remote_addr(self, local_base: u64, peer_base: u64) -> u64 {
-        peer_base.wrapping_add(self.offset_from_u64(local_base))
+    pub(crate) fn to_remote_addr(self, local_base: u64, peer_base: u64) -> Result<u64> {
+        peer_base
+            .checked_add(self.offset_from_u64(local_base)?)
+            .ok_or(Error::Usage("remote symmetric address overflow"))
     }
 }
 
@@ -285,7 +289,7 @@ mod tests {
     #[test]
     fn symmetric_address_translation_preserves_offset() {
         let ptr = SymPtr(0x2234);
-        assert_eq!(ptr.to_remote_addr(0x1000, 0x9000), 0xa234);
+        assert_eq!(ptr.to_remote_addr(0x1000, 0x9000).unwrap(), 0xa234);
     }
 }
 
@@ -296,7 +300,7 @@ mod legacy_tests {
     fn symmetric_peers_compute_consistent_remote_addresses() {
         let a = SymPtr(0x2234);
         let b = SymPtr(0xa234);
-        assert_eq!(a.to_remote_addr(0x1000, 0x9000), 0xa234);
-        assert_eq!(b.to_remote_addr(0x9000, 0x1000), 0x2234);
+        assert_eq!(a.to_remote_addr(0x1000, 0x9000).unwrap(), 0xa234);
+        assert_eq!(b.to_remote_addr(0x9000, 0x1000).unwrap(), 0x2234);
     }
 }


### PR DESCRIPTION
## Summary
- add `ping_put_get` two-PE symmetric RMA example
- add feature-gated N-PE UCC barrier example
- expose symmetric heap allocation/free and pointer offset helpers needed by examples
- document example launch commands and DVM prerequisites

## Coverage audit
Existing phase 1–4 coverage already includes lifecycle queries/finalize, allocator roundtrips, loopback RMA put/get completion, fence/quiet, typed atomic dispatch plus ignored AMO execution, PMIx KVS key/metadata tests plus ignored DVM handshake, and blocking/non-blocking collectives plus ignored DVM smoke tests. No duplicate integration tests were added. The requested examples fill the remaining user-facing gap.

The local host has no daemon/DVM, so the examples are compile-checked only. Multi-PE bootstrap, cross-PE RMA, atomics, and collectives remain DVM/RDMA-only and retain their ignored/manual-run status.

## Validation
- `cargo check --lib`
- `cargo clippy --lib -- -D warnings`
- `cargo test --tests` (17 passed, 3 ignored)
- `cargo check --examples`
- `mkdir -p /tmp/emptyinc && env -u UCC_PREFIX UCC_INCLUDE_DIR=/tmp/emptyinc UCC_LIB_DIR=/home/bzf/lib cargo check --lib --features collectives && cargo check --examples --features collectives`

The local feature-gated compile uses the repository's fallback bindings because UCC headers are not installed; compilation completed successfully. Existing warnings originate in the adjacent `pmix-rs` dependency. No CI workflow change was made: the stale ucx-rs cache issue is known infrastructure context, not clearly actionable in this ticket.

Closes #10
